### PR TITLE
Allow publishing as dotnet global tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,29 @@ name: GitHub CI
 on: push
 
 jobs:
-  build-windows:
-    name: Build (Windows)
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Build
+        shell: pwsh
+        run: ./build.ps1
+
+  publish:
+    name: Publish (Windows)
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
 
       - name: Build
         shell: pwsh
@@ -28,14 +45,33 @@ jobs:
           name: JitDasm-netcoreapp3.0
           path: JitDasm/bin/Release/netcoreapp3.0
 
-  # Make sure it builds on Linux too
-  build-ubuntu:
-    name: Build (Ubuntu)
-    runs-on: ubuntu-latest
+      - name: Pack NuGet packages (CI versions)
+        if: startsWith(github.ref, 'refs/heads/')
+        shell: bash
+        env:
+          PACKING: true
+        run: dotnet pack --configuration Release --output nupkgs --version-suffix "ci.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}" ./JitDasm/JitDasm.csproj
 
-    steps:
-      - uses: actions/checkout@v1
+      - name: Pack NuGet packages (Release versions)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          PACKING: true
+        run: dotnet pack --configuration Release --output nupkgs ./JitDasm/JitDasm.csproj
+        
+      - name: Upload artifacts (nupkg)
+        uses: actions/upload-artifact@v1
+        with:
+          name: JitDasm+sha.${{ github.sha }}
+          path: nupkgs
 
-      - name: Build
-        shell: pwsh
-        run: ./build.ps1
+      - name: Publish packages to GitHub Package Registry 
+        env:  
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE: https://nuget.pkg.github.com/0xd4d/index.json
+        shell: bash
+        run: |
+          cd nupkgs
+          curl -o nuget -L https://dist.nuget.org/win-x86-commandline/latest/nuget.exe  
+          ./nuget sources add -Name "GitHub" -Source $SOURCE -UserName 0xd4d -Password "$TOKEN"
+          ./nuget push "JitDasm.*.nupkg" -Source "GitHub"

--- a/JitDasm/JitDasm.csproj
+++ b/JitDasm/JitDasm.csproj
@@ -2,11 +2,27 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
+    <!-- It's not possible to target .NET Framework 4.7.2 when using dotnet pack
+         together with packaging as a tool -->
+    <NoTargetFrameworkNet472 Condition=" '$(PACKING)' == 'true' ">true</NoTargetFrameworkNet472>
+    <TargetFrameworks Condition=" '$(NoTargetFrameworkNet472)' != 'true' ">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <nullable>enable</nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Features>strict</Features>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>jitdasm</ToolCommandName>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <!-- Nupkg stuff -->
+    <Title>JitDasm</Title>
+    <Description>Disassembles one or more .NET methods / types to stdout or file(s). It can also create diffable disassembly.</Description>
+    <Authors>0xd4d</Authors>
+    <PackageProjectUrl>https://github.com/0xd4d/JitDasm</PackageProjectUrl>
+    <License>https://raw.githubusercontent.com/0xd4d/JitDasm/master/LICENSE.txt</License>
+    <RepositoryUrl>https://github.com/0xd4d/JitDasm</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>jit disassembly</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +30,9 @@
     <PackageReference Include="Iced" Version="1.4.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.57604" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>


### PR DESCRIPTION
* Added nuget properties
* Changed GH workflow to use build matrix for ubuntu/windows, then publish from windows
* Hopefully, it will publish to your own package registry...
* nupkg is prepared and published as an artifact as part of build
* When building a tag released (e.g. `git tag v1.2.3`) the workflow will use the version information as is
* When building a regular version a `.ci-...`  auto generated suffix will be added, for example: `JitDasm.0.1.0-ci.20191129T050514.nupkg`)
* Added source link support, because why not?

Closes https://github.com/0xd4d/JitDasm/issues/2