### PR TITLE
Call Runtime.Flush()

### DIFF
--- a/JitDasm/Program.cs
+++ b/JitDasm/Program.cs
@@ -285,6 +285,8 @@ namespace JitDasm {
 				if (module is null)
 					throw new ApplicationException($"Couldn't find module '{moduleName}'");
 
+				module.Runtime.Flush();
+				
 				foreach (var type in EnumerateTypes(module, heapSearch)) {
 					if (!typeFilter.IsMatch(type.Name, type.MetadataToken))
 						continue;


### PR DESCRIPTION
When COMPlus_TieredCompilation = 0, the output result is random. 
I fixed this problem.

```
>set COMPlus_TieredCompilation=0
>JitDasm -l Test.dll
>JitDasm -l Test.dll
>JitDasm -l Test.dll
```